### PR TITLE
STS 평가 코드 추가

### DIFF
--- a/eval_KorFinMTEB.py
+++ b/eval_KorFinMTEB.py
@@ -47,7 +47,10 @@ TASK_LIST_RERANKING = [
 
 TASK_LIST_STS = [
     # "FinSTS",
-    "KorFinSTS"
+    "KorFinSTS",
+    "KorDartReportSTS",
+    "KorFinLawSTS",
+    "KorFinReportSTS",
 ]
 
 TASK_LIST_PAIRCLASSIFICATION = [

--- a/finance_mteb/tasks/STS/__init__.py
+++ b/finance_mteb/tasks/STS/__init__.py
@@ -4,6 +4,9 @@ from .eng.FINAL import *
 from .eng.FinSTS import *
 
 from .kor.KorFinSTS import *
+from .kor.KorDartReportSTS import *
+from .kor.KorFinLawSTS import *
+from .kor.KorFinReportSTS import *
 
 from .zho.AFQMC import *
 from .zho.BQCorpus import *

--- a/finance_mteb/tasks/STS/kor/KorDartReportSTS.py
+++ b/finance_mteb/tasks/STS/kor/KorDartReportSTS.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 from finance_mteb.abstasks.TaskMetadata import TaskMetadata
 from ....abstasks import AbsTaskSTS
 
-class KorFinSTS(AbsTaskSTS):
+class KorDartReportSTS(AbsTaskSTS):
     metadata = TaskMetadata(
-        name="KorFinSTS",
-        description="금융 텍스트에서 미묘한 의미적 변화를 탐지하여, 문장이 얼마나 유사한지 판단합니다.",
+        name="KorDartReportSTS",
+        description="DART 보고서 텍스트에서 미묘한 의미적 변화를 탐지하여, 문장이 얼마나 유사한지 판단합니다.",
         reference="",
         dataset={
-            "path": "nmixx-fin/NMIXX_kor_fin_news_STS",
+            "path": "nmixx-fin/NMIXX_kor_fin_DART_report_STS",
             "revision": "main",
         },
         type="STS",

--- a/finance_mteb/tasks/STS/kor/KorFinLawSTS.py
+++ b/finance_mteb/tasks/STS/kor/KorFinLawSTS.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 from finance_mteb.abstasks.TaskMetadata import TaskMetadata
 from ....abstasks import AbsTaskSTS
 
-class KorFinSTS(AbsTaskSTS):
+class KorFinLawSTS(AbsTaskSTS):
     metadata = TaskMetadata(
-        name="KorFinSTS",
-        description="금융 텍스트에서 미묘한 의미적 변화를 탐지하여, 문장이 얼마나 유사한지 판단합니다.",
+        name="KorFinLawSTS",
+        description="금융 법률 텍스트에서 미묘한 의미적 변화를 탐지하여, 문장이 얼마나 유사한지 판단합니다.",
         reference="",
         dataset={
-            "path": "nmixx-fin/NMIXX_kor_fin_news_STS",
+            "path": "nmixx-fin/NMIXX_kor_fin_law_STS",
             "revision": "main",
         },
         type="STS",

--- a/finance_mteb/tasks/STS/kor/KorFinReportSTS.py
+++ b/finance_mteb/tasks/STS/kor/KorFinReportSTS.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 from finance_mteb.abstasks.TaskMetadata import TaskMetadata
 from ....abstasks import AbsTaskSTS
 
-class KorFinSTS(AbsTaskSTS):
+class KorFinReportSTS(AbsTaskSTS):
     metadata = TaskMetadata(
-        name="KorFinSTS",
-        description="금융 텍스트에서 미묘한 의미적 변화를 탐지하여, 문장이 얼마나 유사한지 판단합니다.",
+        name="KorFinReportSTS",
+        description="금융 보고서 텍스트에서 미묘한 의미적 변화를 탐지하여, 문장이 얼마나 유사한지 판단합니다.",
         reference="",
         dataset={
-            "path": "nmixx-fin/NMIXX_kor_fin_news_STS",
+            "path": "nmixx-fin/NMIXX_kor_fin_report_STS",
             "revision": "main",
         },
         type="STS",

--- a/results/KURE-v1/no_model_name_available/no_revision_available/KorDartReportSTS.json
+++ b/results/KURE-v1/no_model_name_available/no_revision_available/KorDartReportSTS.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 1.7639498710632324,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.003511932086901007,
+        "cosine_spearman": -0.0016698489832515369,
+        "euclidean_pearson": 0.0028085229498723413,
+        "euclidean_spearman": -0.001725510616026588,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": -0.0016698489832515369,
+        "manhattan_pearson": 0.0010121199678675991,
+        "manhattan_spearman": -0.0021151420454519464,
+        "pearson": -0.003511932086901007,
+        "spearman": -0.0016698489832515369
+      }
+    ]
+  },
+  "task_name": "KorDartReportSTS"
+}

--- a/results/KURE-v1/no_model_name_available/no_revision_available/KorFinLawSTS.json
+++ b/results/KURE-v1/no_model_name_available/no_revision_available/KorFinLawSTS.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 1.345700979232788,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.06424850698077139,
+        "cosine_spearman": -0.08001359711413614,
+        "euclidean_pearson": -0.06822850979617004,
+        "euclidean_spearman": -0.0801805820124613,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": -0.08001359711413614,
+        "manhattan_pearson": -0.07195926603796271,
+        "manhattan_spearman": -0.085301452227766,
+        "pearson": -0.06424850698077139,
+        "spearman": -0.08001359711413614
+      }
+    ]
+  },
+  "task_name": "KorFinLawSTS"
+}

--- a/results/KURE-v1/no_model_name_available/no_revision_available/KorFinReportSTS.json
+++ b/results/KURE-v1/no_model_name_available/no_revision_available/KorFinReportSTS.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 2.1191558837890625,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": 0.04340918699929226,
+        "cosine_spearman": 0.04247272589440986,
+        "euclidean_pearson": 0.045364091065462075,
+        "euclidean_spearman": 0.042552712195529294,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": 0.04247272589440986,
+        "manhattan_pearson": 0.04298125733935912,
+        "manhattan_spearman": 0.040513061516984174,
+        "pearson": 0.04340918699929226,
+        "spearman": 0.04247272589440986
+      }
+    ]
+  },
+  "task_name": "KorFinReportSTS"
+}

--- a/results/KURE-v1/no_model_name_available/no_revision_available/KorFinSTS.json
+++ b/results/KURE-v1/no_model_name_available/no_revision_available/KorFinSTS.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 2.503525972366333,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.053499574400236026,
+        "cosine_spearman": -0.04152357805018821,
+        "euclidean_pearson": -0.05292492183387207,
+        "euclidean_spearman": -0.041607070499350786,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": -0.04152357805018821,
+        "manhattan_pearson": -0.0505055682907071,
+        "manhattan_spearman": -0.04032685294552462,
+        "pearson": -0.053499574400236026,
+        "spearman": -0.04152357805018821
+      }
+    ]
+  },
+  "task_name": "KorFinSTS"
+}

--- a/results/all-MiniLM-L12-v2/sentence-transformers__all-MiniLM-L12-v2/c004d8e3e901237d8fa7e9fff12774962e391ce5/KorDartReportSTS.json
+++ b/results/all-MiniLM-L12-v2/sentence-transformers__all-MiniLM-L12-v2/c004d8e3e901237d8fa7e9fff12774962e391ce5/KorDartReportSTS.json
@@ -1,0 +1,32 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 1.2256126403808594,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.034403684855484236,
+        "cosine_spearman": -0.020344326779281226,
+        "euclidean_pearson": -0.025130375450737236,
+        "euclidean_spearman": -0.020344326779281226,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": -0.020344326779281226,
+        "manhattan_pearson": -0.024856092809116,
+        "manhattan_spearman": -0.022375976375570594,
+        "pearson": [
+          -0.034403750776710665,
+          0.4431878162230422
+        ],
+        "spearman": [
+          -0.020344326779281226,
+          0.6502859173439051
+        ]
+      }
+    ]
+  },
+  "task_name": "KorDartReportSTS"
+}

--- a/results/all-MiniLM-L12-v2/sentence-transformers__all-MiniLM-L12-v2/c004d8e3e901237d8fa7e9fff12774962e391ce5/KorFinLawSTS.json
+++ b/results/all-MiniLM-L12-v2/sentence-transformers__all-MiniLM-L12-v2/c004d8e3e901237d8fa7e9fff12774962e391ce5/KorFinLawSTS.json
@@ -1,0 +1,32 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 1.1976990699768066,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.0536537112605465,
+        "cosine_spearman": -0.03609656885462072,
+        "euclidean_pearson": -0.05607417402856171,
+        "euclidean_spearman": -0.03609656885462072,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": -0.03609656885462072,
+        "manhattan_pearson": -0.056929322037537616,
+        "manhattan_spearman": -0.038740496411435656,
+        "pearson": [
+          -0.053653735860968665,
+          0.23154449796353302
+        ],
+        "spearman": [
+          -0.03609656885462072,
+          0.42106423266873916
+        ]
+      }
+    ]
+  },
+  "task_name": "KorFinLawSTS"
+}

--- a/results/all-MiniLM-L12-v2/sentence-transformers__all-MiniLM-L12-v2/c004d8e3e901237d8fa7e9fff12774962e391ce5/KorFinReportSTS.json
+++ b/results/all-MiniLM-L12-v2/sentence-transformers__all-MiniLM-L12-v2/c004d8e3e901237d8fa7e9fff12774962e391ce5/KorFinReportSTS.json
@@ -1,0 +1,32 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 1.1163330078125,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.05228387154446377,
+        "cosine_spearman": -0.052750965588254824,
+        "euclidean_pearson": -0.04785444486828329,
+        "euclidean_spearman": -0.052750965588254824,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": -0.052750965588254824,
+        "manhattan_pearson": -0.048957289860421006,
+        "manhattan_spearman": -0.05451066421288196,
+        "pearson": [
+          -0.05228393776840183,
+          0.2844755941892604
+        ],
+        "spearman": [
+          -0.052750965588254824,
+          0.2801897102544013
+        ]
+      }
+    ]
+  },
+  "task_name": "KorFinReportSTS"
+}

--- a/results/all-MiniLM-L12-v2/sentence-transformers__all-MiniLM-L12-v2/c004d8e3e901237d8fa7e9fff12774962e391ce5/KorFinSTS.json
+++ b/results/all-MiniLM-L12-v2/sentence-transformers__all-MiniLM-L12-v2/c004d8e3e901237d8fa7e9fff12774962e391ce5/KorFinSTS.json
@@ -1,0 +1,32 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 1.569234848022461,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.09881765532103079,
+        "cosine_spearman": -0.08254620937760691,
+        "euclidean_pearson": -0.10221621561130942,
+        "euclidean_spearman": -0.08254620937760691,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": -0.08254620937760691,
+        "manhattan_pearson": -0.10027821712436198,
+        "manhattan_spearman": -0.0800692664798972,
+        "pearson": [
+          -0.09881765056136285,
+          0.027293948684977185
+        ],
+        "spearman": [
+          -0.08254620339845223,
+          0.06540738853089707
+        ]
+      }
+    ]
+  },
+  "task_name": "KorFinSTS"
+}

--- a/results/bge-en-icl/no_model_name_available/no_revision_available/KorDartReportSTS.json
+++ b/results/bge-en-icl/no_model_name_available/no_revision_available/KorDartReportSTS.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 36.694013833999634,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.019588104941056162,
+        "cosine_spearman": -0.02866574087915138,
+        "euclidean_pearson": -0.01772362151374577,
+        "euclidean_spearman": -0.02891621822663911,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": -0.02866574087915138,
+        "manhattan_pearson": -0.022581006423936748,
+        "manhattan_spearman": -0.033090840684767954,
+        "pearson": -0.019588104941056162,
+        "spearman": -0.02866574087915138
+      }
+    ]
+  },
+  "task_name": "KorDartReportSTS"
+}

--- a/results/bge-en-icl/no_model_name_available/no_revision_available/KorFinLawSTS.json
+++ b/results/bge-en-icl/no_model_name_available/no_revision_available/KorFinLawSTS.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 33.16112756729126,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.07094551344505663,
+        "cosine_spearman": -0.08716611692573023,
+        "euclidean_pearson": -0.06880533258101425,
+        "euclidean_spearman": -0.08711045529295516,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": -0.08716611692573023,
+        "manhattan_pearson": -0.0674752070509287,
+        "manhattan_spearman": -0.08368726487728952,
+        "pearson": -0.07094551344505663,
+        "spearman": -0.08716611692573023
+      }
+    ]
+  },
+  "task_name": "KorFinLawSTS"
+}

--- a/results/bge-en-icl/no_model_name_available/no_revision_available/KorFinReportSTS.json
+++ b/results/bge-en-icl/no_model_name_available/no_revision_available/KorFinReportSTS.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 34.18777060508728,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.0927428581140411,
+        "cosine_spearman": -0.09250415724460453,
+        "euclidean_pearson": -0.09657731257760566,
+        "euclidean_spearman": -0.09246416409404484,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": -0.09250415724460453,
+        "manhattan_pearson": -0.09349702953900693,
+        "manhattan_spearman": -0.08842485588751432,
+        "pearson": -0.0927428581140411,
+        "spearman": -0.09250415724460453
+      }
+    ]
+  },
+  "task_name": "KorFinReportSTS"
+}

--- a/results/bge-en-icl/no_model_name_available/no_revision_available/KorFinSTS.json
+++ b/results/bge-en-icl/no_model_name_available/no_revision_available/KorFinSTS.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 40.668673515319824,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.042780335795177246,
+        "cosine_spearman": -0.05243325807409826,
+        "euclidean_pearson": -0.052406571577223234,
+        "euclidean_spearman": -0.052377596441323206,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": -0.05243325807409826,
+        "manhattan_pearson": -0.04923401528822162,
+        "manhattan_spearman": -0.048453451330682094,
+        "pearson": -0.042780335795177246,
+        "spearman": -0.05243325807409826
+      }
+    ]
+  },
+  "task_name": "KorFinSTS"
+}

--- a/results/bge-large-en-v1.5/no_model_name_available/no_revision_available/KorDartReportSTS.json
+++ b/results/bge-large-en-v1.5/no_model_name_available/no_revision_available/KorDartReportSTS.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 2.6720902919769287,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.03619060161621993,
+        "cosine_spearman": -0.018034369019116595,
+        "euclidean_pearson": -0.03337228520923294,
+        "euclidean_spearman": -0.018062199835504122,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": -0.018034369019116595,
+        "manhattan_pearson": -0.03417011250648596,
+        "manhattan_spearman": -0.0192310941237802,
+        "pearson": -0.03619060161621993,
+        "spearman": -0.018034369019116595
+      }
+    ]
+  },
+  "task_name": "KorDartReportSTS"
+}

--- a/results/bge-large-en-v1.5/no_model_name_available/no_revision_available/KorFinLawSTS.json
+++ b/results/bge-large-en-v1.5/no_model_name_available/no_revision_available/KorFinLawSTS.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 2.667877674102783,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.09888837426745163,
+        "cosine_spearman": -0.08237921650707582,
+        "euclidean_pearson": -0.09109925611395014,
+        "euclidean_spearman": -0.08237921650707582,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": -0.08237921650707582,
+        "manhattan_pearson": -0.09079013146648064,
+        "manhattan_spearman": -0.08240704732346334,
+        "pearson": -0.09888837426745163,
+        "spearman": -0.08237921650707582
+      }
+    ]
+  },
+  "task_name": "KorFinLawSTS"
+}

--- a/results/bge-large-en-v1.5/no_model_name_available/no_revision_available/KorFinReportSTS.json
+++ b/results/bge-large-en-v1.5/no_model_name_available/no_revision_available/KorFinReportSTS.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 2.2931408882141113,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.027732326465488177,
+        "cosine_spearman": -0.004159287658209629,
+        "euclidean_pearson": -0.02060215304948449,
+        "euclidean_spearman": -0.004119294507649921,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": -0.004159287658209629,
+        "manhattan_pearson": -0.022731139693307752,
+        "manhattan_spearman": -0.0065188835412324,
+        "pearson": -0.027732326465488177,
+        "spearman": -0.004159287658209629
+      }
+    ]
+  },
+  "task_name": "KorFinReportSTS"
+}

--- a/results/bge-large-en-v1.5/no_model_name_available/no_revision_available/KorFinSTS.json
+++ b/results/bge-large-en-v1.5/no_model_name_available/no_revision_available/KorFinSTS.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 2.9404232501983643,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.005034884304113666,
+        "cosine_spearman": 0.002504773474877305,
+        "euclidean_pearson": 0.0006426011571388744,
+        "euclidean_spearman": 0.00247694265848978,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": 0.002504773474877305,
+        "manhattan_pearson": 0.00020920509260161958,
+        "manhattan_spearman": 0.0013915408193762807,
+        "pearson": -0.005034884304113666,
+        "spearman": 0.002504773474877305
+      }
+    ]
+  },
+  "task_name": "KorFinSTS"
+}

--- a/results/e5-mistral-7b-instruct/no_model_name_available/no_revision_available/KorDartReportSTS.json
+++ b/results/e5-mistral-7b-instruct/no_model_name_available/no_revision_available/KorDartReportSTS.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 34.63398718833923,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.008656228891170372,
+        "cosine_spearman": -0.006735057565781199,
+        "euclidean_pearson": -0.0017420382111733917,
+        "euclidean_spearman": -0.006651565116618622,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": -0.006735057565781199,
+        "manhattan_pearson": -0.004983518769405092,
+        "manhattan_spearman": -0.007208181444369134,
+        "pearson": -0.008656228891170372,
+        "spearman": -0.006735057565781199
+      }
+    ]
+  },
+  "task_name": "KorDartReportSTS"
+}

--- a/results/e5-mistral-7b-instruct/no_model_name_available/no_revision_available/KorFinLawSTS.json
+++ b/results/e5-mistral-7b-instruct/no_model_name_available/no_revision_available/KorFinLawSTS.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 30.05252695083618,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.025554612433492736,
+        "cosine_spearman": -0.04191320947961358,
+        "euclidean_pearson": -0.02379850063431399,
+        "euclidean_spearman": -0.04230284090903893,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": -0.04191320947961358,
+        "manhattan_pearson": -0.025468177545240264,
+        "manhattan_spearman": -0.040827807640500084,
+        "pearson": -0.025554612433492736,
+        "spearman": -0.04191320947961358
+      }
+    ]
+  },
+  "task_name": "KorFinLawSTS"
+}

--- a/results/e5-mistral-7b-instruct/no_model_name_available/no_revision_available/KorFinReportSTS.json
+++ b/results/e5-mistral-7b-instruct/no_model_name_available/no_revision_available/KorFinReportSTS.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 35.039352893829346,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.04848871281516369,
+        "cosine_spearman": -0.04975147929627672,
+        "euclidean_pearson": -0.05359482818325737,
+        "euclidean_spearman": -0.04975147929627672,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": -0.04975147929627672,
+        "manhattan_pearson": -0.04976239718718087,
+        "manhattan_spearman": -0.044952301229111764,
+        "pearson": -0.04848871281516369,
+        "spearman": -0.04975147929627672
+      }
+    ]
+  },
+  "task_name": "KorFinReportSTS"
+}

--- a/results/e5-mistral-7b-instruct/no_model_name_available/no_revision_available/KorFinSTS.json
+++ b/results/e5-mistral-7b-instruct/no_model_name_available/no_revision_available/KorFinSTS.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 36.18683576583862,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.04024132006397927,
+        "cosine_spearman": -0.033536133746968365,
+        "euclidean_pearson": -0.040436567972990334,
+        "euclidean_spearman": -0.0335639645633559,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": -0.033536133746968365,
+        "manhattan_pearson": -0.03197427126890255,
+        "manhattan_spearman": -0.027496846590875305,
+        "pearson": -0.04024132006397927,
+        "spearman": -0.033536133746968365
+      }
+    ]
+  },
+  "task_name": "KorFinSTS"
+}

--- a/results/gte-Qwen2-1.5B-instruct/no_model_name_available/no_revision_available/KorDartReportSTS.json
+++ b/results/gte-Qwen2-1.5B-instruct/no_model_name_available/no_revision_available/KorDartReportSTS.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 38.497400522232056,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.0034867091770348375,
+        "cosine_spearman": 0.008599722263745415,
+        "euclidean_pearson": 0.006312079165927249,
+        "euclidean_spearman": 0.008599722263745415,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": 0.008599722263745415,
+        "manhattan_pearson": 0.007861580015961614,
+        "manhattan_spearman": 0.007124688995206557,
+        "pearson": -0.0034867091770348375,
+        "spearman": 0.008599722263745415
+      }
+    ]
+  },
+  "task_name": "KorDartReportSTS"
+}

--- a/results/gte-Qwen2-1.5B-instruct/no_model_name_available/no_revision_available/KorFinLawSTS.json
+++ b/results/gte-Qwen2-1.5B-instruct/no_model_name_available/no_revision_available/KorFinLawSTS.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 37.975773334503174,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.07577756672883479,
+        "cosine_spearman": -0.0692152403557762,
+        "euclidean_pearson": -0.09410821735166011,
+        "euclidean_spearman": -0.06927090198855125,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": -0.0692152403557762,
+        "manhattan_pearson": -0.09348789411805598,
+        "manhattan_spearman": -0.06779586872001239,
+        "pearson": -0.07577756672883479,
+        "spearman": -0.0692152403557762
+      }
+    ]
+  },
+  "task_name": "KorFinLawSTS"
+}

--- a/results/gte-Qwen2-1.5B-instruct/no_model_name_available/no_revision_available/KorFinReportSTS.json
+++ b/results/gte-Qwen2-1.5B-instruct/no_model_name_available/no_revision_available/KorFinReportSTS.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 32.13898539543152,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.00411616293363502,
+        "cosine_spearman": 0.0036393767009334256,
+        "euclidean_pearson": -0.0036594427403357013,
+        "euclidean_spearman": 0.00355939039981401,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": 0.0036393767009334256,
+        "manhattan_pearson": 0.0012998802274640092,
+        "manhattan_spearman": 0.007798664359143054,
+        "pearson": -0.00411616293363502,
+        "spearman": 0.0036393767009334256
+      }
+    ]
+  },
+  "task_name": "KorFinReportSTS"
+}

--- a/results/gte-Qwen2-1.5B-instruct/no_model_name_available/no_revision_available/KorFinSTS.json
+++ b/results/gte-Qwen2-1.5B-instruct/no_model_name_available/no_revision_available/KorFinSTS.json
@@ -1,0 +1,26 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 44.586505651474,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.028642504852181543,
+        "cosine_spearman": -0.024574610870185115,
+        "euclidean_pearson": -0.03278871491682678,
+        "euclidean_spearman": -0.024518949237410066,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": -0.024574610870185115,
+        "manhattan_pearson": -0.029951742650416367,
+        "manhattan_spearman": -0.020566973310381428,
+        "pearson": -0.028642504852181543,
+        "spearman": -0.024574610870185115
+      }
+    ]
+  },
+  "task_name": "KorFinSTS"
+}

--- a/results/instructor-base/hkunlp__instructor-base/0b2f22542d2bd6d60dbff22d22f12c15e6562736/KorDartReportSTS.json
+++ b/results/instructor-base/hkunlp__instructor-base/0b2f22542d2bd6d60dbff22d22f12c15e6562736/KorDartReportSTS.json
@@ -1,0 +1,32 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 2.371722936630249,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.05524627256031726,
+        "cosine_spearman": 0.007945698654177517,
+        "euclidean_pearson": -0.02865581261511813,
+        "euclidean_spearman": 0.0079317826704448,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": 0.007945698654177517,
+        "manhattan_pearson": -0.028043428312685442,
+        "manhattan_spearman": 0.00926766185704603,
+        "pearson": [
+          -0.05524734205885942,
+          0.21795725267420948
+        ],
+        "spearman": [
+          0.007917867835774093,
+          0.8599553849659599
+        ]
+      }
+    ]
+  },
+  "task_name": "KorDartReportSTS"
+}

--- a/results/instructor-base/hkunlp__instructor-base/0b2f22542d2bd6d60dbff22d22f12c15e6562736/KorFinLawSTS.json
+++ b/results/instructor-base/hkunlp__instructor-base/0b2f22542d2bd6d60dbff22d22f12c15e6562736/KorFinLawSTS.json
@@ -1,0 +1,32 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 2.1236464977264404,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.021453693390108892,
+        "cosine_spearman": 0.11737647661644021,
+        "euclidean_pearson": 0.026572375291614048,
+        "euclidean_spearman": 0.11739038352258305,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": 0.11737647661644021,
+        "manhattan_pearson": 0.026169991799557046,
+        "manhattan_spearman": 0.11719556780787035,
+        "pearson": [
+          -0.021452827566301947,
+          0.6325982109895041
+        ],
+        "spearman": [
+          0.11737647378242302,
+          0.00867778731736429
+        ]
+      }
+    ]
+  },
+  "task_name": "KorFinLawSTS"
+}

--- a/results/instructor-base/hkunlp__instructor-base/0b2f22542d2bd6d60dbff22d22f12c15e6562736/KorFinReportSTS.json
+++ b/results/instructor-base/hkunlp__instructor-base/0b2f22542d2bd6d60dbff22d22f12c15e6562736/KorFinReportSTS.json
@@ -1,0 +1,32 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 2.394336462020874,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": 0.07114856655879088,
+        "cosine_spearman": 0.07640691721624351,
+        "euclidean_pearson": 0.08112487100013956,
+        "euclidean_spearman": 0.07642691071960193,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": 0.07640691721624351,
+        "manhattan_pearson": 0.08107193674610524,
+        "manhattan_spearman": 0.07650689702072135,
+        "pearson": [
+          0.07114896691714347,
+          0.1450165412856489
+        ],
+        "spearman": [
+          0.07642691686505308,
+          0.11740068143763942
+        ]
+      }
+    ]
+  },
+  "task_name": "KorFinReportSTS"
+}

--- a/results/instructor-base/hkunlp__instructor-base/0b2f22542d2bd6d60dbff22d22f12c15e6562736/KorFinSTS.json
+++ b/results/instructor-base/hkunlp__instructor-base/0b2f22542d2bd6d60dbff22d22f12c15e6562736/KorFinSTS.json
@@ -1,0 +1,32 @@
+{
+  "dataset_revision": "main",
+  "evaluation_time": 2.5389435291290283,
+  "kg_co2_emissions": null,
+  "mteb_version": "1.12.49",
+  "scores": {
+    "train": [
+      {
+        "cosine_pearson": -0.07088551903114593,
+        "cosine_spearman": -0.05571759171619294,
+        "euclidean_pearson": -0.08088844726406115,
+        "euclidean_spearman": -0.05580100916147378,
+        "hf_subset": "default",
+        "languages": [
+          "kor-Hang"
+        ],
+        "main_score": -0.05571759171619294,
+        "manhattan_pearson": -0.08171206862706368,
+        "manhattan_spearman": -0.05613498028862474,
+        "pearson": [
+          -0.0708859193224673,
+          0.11376599191003674
+        ],
+        "spearman": [
+          -0.05542514711447276,
+          0.216477461461987
+        ]
+      }
+    ]
+  },
+  "task_name": "KorFinSTS"
+}


### PR DESCRIPTION
STS 총 4가지 데이터셋에 대한 평가코드를 추가했습니다.
결과는 Result 폴더에서 확인 가능합니다.
총 4가지 데이터셋은 기존 FinSTS 데이터셋 + 새롭게 추가된 데이터셋 3가지입니다.
(법률 관련 KorFinLawSTS // 다트보고서 관련 KorDartReportSTS // 투자리포트 관련 KorFinReportSTS)